### PR TITLE
Ensure review queue persists after task retrieval

### DIFF
--- a/core/queue_manager.py
+++ b/core/queue_manager.py
@@ -29,7 +29,9 @@ class ReviewQueueManager:
     def get_next_task(self):
         with self.lock:
             if self.queue:
-                return self.queue.pop(0)
+                task = self.queue.pop(0)
+                self._save_queue()
+                return task
             return None
 
     def peek(self):

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,24 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.abspath("."))
+
+from core.queue_manager import ReviewQueueManager
+
+
+def test_get_next_task_persists(tmp_path):
+    queue_file = tmp_path / "queue.json"
+    manager = ReviewQueueManager(path=str(queue_file))
+    manager.add_task({"id": 1})
+    manager.add_task({"id": 2})
+
+    task = manager.get_next_task()
+    assert task == {"id": 1}
+    with open(queue_file) as f:
+        assert json.load(f) == [{"id": 2}]
+
+    task = manager.get_next_task()
+    assert task == {"id": 2}
+    with open(queue_file) as f:
+        assert json.load(f) == []


### PR DESCRIPTION
## Summary
- Persist queue file after retrieving tasks to keep storage in sync
- Add regression test verifying queue file updates on task retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeeb6d08388327ab1e9aad36689083