### PR TITLE
Refactor heartbeat config loading

### DIFF
--- a/remote/heartbeat.py
+++ b/remote/heartbeat.py
@@ -1,13 +1,28 @@
-import json, time
-from config.agent_config import load_config
+import json
+import time
+from pathlib import Path
+
+# Cache the configuration and reload only when the file changes
+_CONFIG_CACHE = None
+_CONFIG_MTIME = 0
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "agent_config.json"
 
 def load_config():
-    with open('config/agent_config.json') as f:
-        return json.load(f)
+    """Load the agent configuration with simple caching.
+
+    The JSON file is only read when it changes on disk.
+    """
+    global _CONFIG_CACHE, _CONFIG_MTIME
+    mtime = CONFIG_PATH.stat().st_mtime
+    if _CONFIG_CACHE is None or mtime != _CONFIG_MTIME:
+        with CONFIG_PATH.open() as f:
+            _CONFIG_CACHE = json.load(f)
+        _CONFIG_MTIME = mtime
+    return _CONFIG_CACHE
 
 def heartbeat():
-    config = load_config()
     while True:
+        config = load_config()
         print(f"Heartbeat from {config['agent_name']} at {time.ctime()}")
         time.sleep(config['heartbeat_interval'])
 


### PR DESCRIPTION
## Summary
- remove invalid import of load_config from non-existent module
- add cached configuration loader in `remote/heartbeat.py`
- reload config when file changes and call loader inside heartbeat loop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeec73a874832793c7d0557da2f698