### PR TITLE
Add resilient OpenAI request handling

### DIFF
--- a/core/api_utils.py
+++ b/core/api_utils.py
@@ -1,0 +1,24 @@
+import json
+import os
+from pathlib import Path
+
+
+def get_openai_api_key():
+    """Retrieve the OpenAI API key from environment or config file."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        return api_key
+
+    config_path = Path(__file__).resolve().parent.parent / "config" / "settings.json"
+    if config_path.exists():
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                api_key = data.get("openai_api_key")
+                if api_key:
+                    return api_key
+        except json.JSONDecodeError:
+            pass
+    raise EnvironmentError(
+        "OpenAI API key not found. Set OPENAI_API_KEY env variable or provide it in config/settings.json."
+    )

--- a/core/review_spinner.py
+++ b/core/review_spinner.py
@@ -1,10 +1,26 @@
 import openai
 
-def generate_variants(prompt, n=3):
-    openai.api_key = "sk-PLACEHOLDER"
-    responses = openai.ChatCompletion.create(
+from core.api_utils import get_openai_api_key
+from core.logger import logger
+from core.retry_handler import retry
+
+
+openai.api_key = get_openai_api_key()
+
+
+@retry(max_attempts=3, delay=2, backoff=2)
+def _create_variants(prompt, n):
+    return openai.ChatCompletion.create(
         model="gpt-4",
         messages=[{"role": "user", "content": prompt}],
-        n=n
+        n=n,
     )
-    return [choice['message']['content'] for choice in responses['choices']]
+
+
+def generate_variants(prompt, n=3):
+    try:
+        responses = _create_variants(prompt, n)
+        return [choice["message"]["content"] for choice in responses["choices"]]
+    except Exception as e:
+        logger.error(f"Failed to generate variants: {e}")
+        return []

--- a/core/style_generator.py
+++ b/core/style_generator.py
@@ -1,35 +1,45 @@
 import openai
-import json
-import random
+import time
 
-def load_config():
-    with open("config/settings.json") as f:
-        return json.load(f)
+from core.api_utils import get_openai_api_key
+from core.logger import logger
+from core.retry_handler import retry
+
+
+openai.api_key = get_openai_api_key()
+
+
+tones = {
+    "professional": "Write in a calm, factual tone suitable for a business or legal audience.",
+    "emotional": "Write with raw, personal emotion and frustration.",
+    "rhetorical": "Use rhetorical questions and sarcasm to emphasize injustice.",
+    "legalese": "Write using formal legal language and ethical violations.",
+    "outraged": "Write with high-impact, accusatory language.",
+}
+
+
+@retry(max_attempts=3, delay=2, backoff=2)
+def _generate_single_review(prompt, tone_prompt):
+    return openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": tone_prompt},
+            {"role": "user", "content": f"Write a negative review based on: {prompt}"},
+        ],
+        max_tokens=300,
+    )
+
 
 def generate_styled_reviews(prompt, count=5, tone="professional"):
-    config = load_config()
-    openai.api_key = config["openai_api_key"]
-
-    tones = {
-        "professional": "Write in a calm, factual tone suitable for a business or legal audience.",
-        "emotional": "Write with raw, personal emotion and frustration.",
-        "rhetorical": "Use rhetorical questions and sarcasm to emphasize injustice.",
-        "legalese": "Write using formal legal language and ethical violations.",
-        "outraged": "Write with high-impact, accusatory language."
-    }
-
     tone_prompt = tones.get(tone, tones["professional"])
 
     responses = []
     for _ in range(count):
-        response = openai.ChatCompletion.create(
-            model="gpt-4",
-            messages=[
-                {"role": "system", "content": tone_prompt},
-                {"role": "user", "content": f"Write a negative review based on: {prompt}"}
-            ],
-            max_tokens=300
-        )
-        review = response["choices"][0]["message"]["content"]
-        responses.append(review.strip())
+        try:
+            response = _generate_single_review(prompt, tone_prompt)
+            review = response["choices"][0]["message"]["content"]
+            responses.append(review.strip())
+            time.sleep(1)
+        except Exception as e:
+            logger.error(f"Failed to generate styled review: {e}")
     return responses


### PR DESCRIPTION
## Summary
- Load OpenAI API key from environment or config file
- Wrap OpenAI calls with retry logic and error logging
- Apply basic rate limiting to review generation utilities

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeec90b9f88327a744773a1ba102e6