### PR TITLE
feat(gui): add proxy manager panel

### DIFF
--- a/dashboard/main_gui.py
+++ b/dashboard/main_gui.py
@@ -3,6 +3,9 @@ import tkinter as tk
 from tkinter import ttk
 from tkinter.scrolledtext import ScrolledText
 
+from proxy.manager import ProxyManager
+from gui.proxy_manager_gui import ProxyManagerFrame
+
 class GuardianDeck(tk.Tk):
     def __init__(self):
         super().__init__()
@@ -40,9 +43,9 @@ class GuardianDeck(tk.Tk):
         self.template_list.pack(fill='both', expand=True, padx=10, pady=5)
 
     def create_proxy_tab(self, frame):
-        ttk.Label(frame, text="Proxies / Accounts in Use:").pack(anchor='w')
-        self.proxy_display = ScrolledText(frame, height=10)
-        self.proxy_display.pack(fill='both', expand=True, padx=10, pady=5)
+        manager = ProxyManager(path="proxy/proxy_list.txt")
+        proxy_frame = ProxyManagerFrame(frame, manager)
+        proxy_frame.pack(fill='both', expand=True, padx=10, pady=5)
 
     def create_scheduler_tab(self, frame):
         ttk.Label(frame, text="Scheduler Status:").pack(anchor='w')

--- a/gui/proxy_manager_gui.py
+++ b/gui/proxy_manager_gui.py
@@ -1,0 +1,51 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from proxy.manager import ProxyManager
+
+
+class ProxyManagerFrame(ttk.Frame):
+    """UI component for managing proxies."""
+
+    def __init__(self, master, manager: ProxyManager):
+        super().__init__(master)
+        self.manager = manager
+        self.create_widgets()
+        self.refresh_list()
+
+    def create_widgets(self) -> None:
+        self.listbox = tk.Listbox(self)
+        self.listbox.pack(fill='both', expand=True, padx=5, pady=5)
+
+        entry_frame = ttk.Frame(self)
+        entry_frame.pack(fill='x', padx=5, pady=5)
+
+        self.entry = ttk.Entry(entry_frame)
+        self.entry.pack(side='left', fill='x', expand=True)
+
+        ttk.Button(entry_frame, text="Add", command=self.add_proxy).pack(side='left', padx=5)
+        ttk.Button(entry_frame, text="Remove", command=self.remove_selected).pack(side='left')
+
+    def refresh_list(self) -> None:
+        self.listbox.delete(0, tk.END)
+        for proxy in self.manager.proxies:
+            self.listbox.insert(tk.END, proxy)
+
+    def add_proxy(self) -> None:
+        proxy = self.entry.get().strip()
+        if proxy:
+            try:
+                self.manager.add_proxy(proxy)
+                self.refresh_list()
+                self.entry.delete(0, tk.END)
+            except Exception as e:
+                messagebox.showerror("Error", str(e))
+
+    def remove_selected(self) -> None:
+        selection = self.listbox.curselection()
+        if selection:
+            proxy = self.listbox.get(selection[0])
+            try:
+                self.manager.remove_proxy(proxy)
+                self.refresh_list()
+            except Exception as e:
+                messagebox.showerror("Error", str(e))

--- a/proxy/manager.py
+++ b/proxy/manager.py
@@ -1,0 +1,42 @@
+import os
+from typing import List
+
+
+class ProxyManager:
+    """Manage list of proxies with persistence to disk."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.proxies: List[str] = []
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, 'r', encoding='utf-8') as f:
+                    self.proxies = [line.strip() for line in f if line.strip()]
+            except Exception:
+                # If file is corrupt or unreadable, start with empty list
+                self.proxies = []
+        else:
+            self.proxies = []
+
+    def _save(self) -> None:
+        try:
+            with open(self.path, 'w', encoding='utf-8') as f:
+                for proxy in self.proxies:
+                    f.write(proxy + '\n')
+        except Exception as e:
+            # Raise to allow calling code to handle
+            raise e
+
+    def add_proxy(self, proxy: str) -> None:
+        proxy = proxy.strip()
+        if proxy and proxy not in self.proxies:
+            self.proxies.append(proxy)
+            self._save()
+
+    def remove_proxy(self, proxy: str) -> None:
+        if proxy in self.proxies:
+            self.proxies.remove(proxy)
+            self._save()

--- a/tests/test_proxy_manager.py
+++ b/tests/test_proxy_manager.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("."))
+
+from proxy.manager import ProxyManager
+
+
+def test_add_remove_proxy_persists(tmp_path):
+    file_path = tmp_path / "proxies.txt"
+    manager = ProxyManager(path=str(file_path))
+
+    manager.add_proxy("http://1.2.3.4:8080")
+    assert manager.proxies == ["http://1.2.3.4:8080"]
+    assert file_path.read_text().strip() == "http://1.2.3.4:8080"
+
+    manager.add_proxy("http://1.2.3.5:8080")
+    manager.remove_proxy("http://1.2.3.4:8080")
+    assert manager.proxies == ["http://1.2.3.5:8080"]
+    assert file_path.read_text().strip() == "http://1.2.3.5:8080"


### PR DESCRIPTION
## Summary
- add ProxyManager to persist proxy lists
- create ProxyManagerFrame for GUI-based proxy editing and wire into dashboard
- test proxy manager persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeefada498832781a7679286cd42d7