### PR TITLE
Add validation for site configurations

### DIFF
--- a/gui/site_manager_gui.py
+++ b/gui/site_manager_gui.py
@@ -49,10 +49,11 @@ class SiteManagerFrame(ttk.Frame):
             return
         data["selectors"] = selectors
         data["navigation_steps"] = steps
-        if not data["site"] or not data["url"]:
-            messagebox.showwarning("Site", "Name and URL required")
+        try:
+            filename = save_site(data)
+        except ValueError as exc:
+            messagebox.showerror("Site", str(exc))
             return
-        filename = save_site(data)
         self.current_name = data["site"]
         self._load_sites()
         self._refresh_list()


### PR DESCRIPTION
## Summary
- enforce required fields and allowed values when saving site configurations
- surface validation errors to the Sites GUI for clearer user feedback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af23475a6483278e6b4e5610799adb