### PR TITLE
Handle non-dict site template JSON files

### DIFF
--- a/core/site_config_loader.py
+++ b/core/site_config_loader.py
@@ -11,7 +11,15 @@ class SiteConfigLoader:
         for template_file in self.templates_path.glob("*.json"):
             with open(template_file, "r", encoding="utf-8") as f:
                 try:
-                    self.site_templates[template_file.stem] = json.load(f)
+                    data = json.load(f)
                 except json.JSONDecodeError:
                     print(f"Warning: Failed to parse {template_file}")
+                    continue
+
+            if isinstance(data, dict):
+                self.site_templates[template_file.stem] = data
+            else:
+                print(
+                    f"Warning: Unexpected JSON format in {template_file}; expected object, got {type(data).__name__}"
+                )
         return self.site_templates


### PR DESCRIPTION
## Summary
- Skip JSON files that aren't objects when loading site templates to avoid attribute errors in the GUI.
- Emit warnings for templates with unexpected structure.

## Testing
- `pytest -q`
- `python -m dashboard.main_gui` *(fails: ModuleNotFoundError: No module named 'openai.error')*

------
https://chatgpt.com/codex/tasks/task_e_68afd9badae48327ab2358b220e4544c