### PR TITLE
Load review site templates

### DIFF
--- a/core/site_config_loader.py
+++ b/core/site_config_loader.py
@@ -16,10 +16,28 @@ class SiteConfigLoader:
                     print(f"Warning: Failed to parse {template_file}")
                     continue
 
+            # Handle a single site config stored as an object
             if isinstance(data, dict):
-                self.site_templates[template_file.stem] = data
-            else:
-                print(
-                    f"Warning: Unexpected JSON format in {template_file}; expected object, got {type(data).__name__}"
-                )
+                key = data.get("site_key", template_file.stem)
+                self.site_templates[key] = data
+                continue
+
+            # Handle a list of site configs (e.g. review_site_templates.json)
+            if isinstance(data, list):
+                for entry in data:
+                    if not isinstance(entry, dict):
+                        print(
+                            f"Warning: Unexpected entry in {template_file}; expected object, got {type(entry).__name__}"
+                        )
+                        continue
+                    key = entry.get("site_key")
+                    if not key:
+                        print(f"Warning: Missing 'site_key' in entry from {template_file}")
+                        continue
+                    self.site_templates[key] = entry
+                continue
+
+            print(
+                f"Warning: Unexpected JSON format in {template_file}; expected object or list, got {type(data).__name__}"
+            )
         return self.site_templates

--- a/dashboard/main_gui.py
+++ b/dashboard/main_gui.py
@@ -498,7 +498,12 @@ class GuardianDeck(tk.Tk):
         text = ScrolledText(frame)
         text.pack(fill="both", expand=True, padx=10, pady=5)
         for name, conf in sites.items():
-            text.insert("end", f"{name}: {list(conf.get('fields', {}).keys())}\n")
+            fields = conf.get("fields") or conf.get("review_fields", [])
+            if isinstance(fields, dict):
+                field_names = list(fields.keys())
+            else:
+                field_names = list(fields)
+            text.insert("end", f"{name}: {field_names}\n")
         text.config(state="disabled")
 
     # --- SCHEDULER ----------------------------------------------------

--- a/tests/test_site_config_loader.py
+++ b/tests/test_site_config_loader.py
@@ -1,0 +1,9 @@
+from core.site_config_loader import SiteConfigLoader
+
+def test_loader_parses_review_site_templates():
+    loader = SiteConfigLoader('templates')
+    templates = loader.load_templates()
+    assert 'google_reviews' in templates
+    assert 'bbb_scam_tracker' in templates
+    assert isinstance(templates['google_reviews'].get('review_fields'), list)
+


### PR DESCRIPTION
## Summary
- Support loading site templates defined as arrays in JSON files
- Display fields from review templates in the sites tab
- Add regression test for loading review site templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afdce4d03883278f700b9d1528a936