### PR TITLE
Add account metadata import/export utilities

### DIFF
--- a/core/account_manager.py
+++ b/core/account_manager.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 """Account utilities backed by the central database."""
 
+import csv
+import io
+import logging
+from typing import Dict, List
+
 from . import database
+
+
+logger = logging.getLogger(__name__)
+
+FIELDS = ["username", "password", "site_name", "login_url", "captcha", "phone"]
 
 
 def load_accounts() -> list[dict]:
@@ -15,3 +25,60 @@ def get_random_account() -> dict | None:
 
 def mark_account_failed(account_id: int) -> None:
     database.mark_account_failed(account_id)
+
+
+def import_accounts_from_text(text: str) -> List[Dict[str, str]]:
+    """Parse accounts from a CSV-formatted string.
+
+    Each line must contain: username,password,site_name,login_url,captcha,phone.
+    Lines missing username or password are skipped and an error is logged.
+    """
+
+    accounts: List[Dict[str, str]] = []
+    reader = csv.DictReader(io.StringIO(text), fieldnames=FIELDS)
+    for line_no, row in enumerate(reader, 1):
+        username = (row.get("username") or "").strip()
+        password = (row.get("password") or "").strip()
+        if not username or not password:
+            logger.error("Line %d missing username or password", line_no)
+            continue
+        account = {field: (row.get(field) or "").strip() or None for field in FIELDS}
+        accounts.append(account)
+    return accounts
+
+
+def export_accounts_to_text(accounts: List[Dict[str, object]]) -> str:
+    """Export accounts to CSV text in the same field order as import."""
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    for acc in accounts:
+        meta = acc.get("metadata") or {}
+        writer.writerow([
+            acc.get("username"),
+            acc.get("password"),
+            meta.get("site_name") or acc.get("site_name"),
+            meta.get("login_url") or acc.get("login_url"),
+            meta.get("captcha") or acc.get("captcha"),
+            meta.get("phone") or acc.get("phone"),
+        ])
+    return output.getvalue()
+
+
+def save_accounts(accounts: List[Dict[str, str]], category: str = "", health_status: str = "healthy") -> None:
+    """Persist parsed accounts to the database."""
+
+    for acc in accounts:
+        metadata = {
+            "site_name": acc.get("site_name"),
+            "login_url": acc.get("login_url"),
+            "captcha": acc.get("captcha"),
+            "phone": acc.get("phone"),
+        }
+        database.add_account(
+            acc["username"],
+            acc["password"],
+            category,
+            health_status,
+            metadata=metadata,
+        )

--- a/tests/test_account_io.py
+++ b/tests/test_account_io.py
@@ -1,0 +1,27 @@
+import logging
+import os
+from importlib import reload
+
+
+def test_account_import_export(tmp_path, caplog):
+    os.environ["REVIEWBOT_DB"] = str(tmp_path / "test.db")
+    from core import database, account_manager
+
+    # Reload modules so they pick up the new database path
+    reload(database)
+    reload(account_manager)
+
+    text = "u1,p1,SiteA,https://a.com,recaptcha,123\n" "badline\n" "u2,p2,,,,\n"
+    with caplog.at_level(logging.ERROR):
+        accounts = account_manager.import_accounts_from_text(text)
+    # One invalid line should be logged and skipped
+    assert len(accounts) == 2
+    assert "missing username or password" in caplog.text
+
+    account_manager.save_accounts(accounts, category="test")
+
+    all_accounts = database.get_all_accounts()
+    exported = account_manager.export_accounts_to_text(all_accounts)
+    assert "u1,p1,SiteA,https://a.com,recaptcha,123" in exported
+    assert "u2,p2" in exported
+


### PR DESCRIPTION
## Summary
- allow accounts table to store arbitrary metadata
- add helpers to import and export account details from CSV text
- cover new account import/export workflow with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b070156aec83279d15c1c750db48c7