### PR TITLE
feat: support scoped proxy assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,11 @@ Proxies disguise your network location.
 2. Type a proxy in the form `IP:PORT` or `USER:PASS@IP:PORT` and press **Add**.
 3. The table shows each proxy's status and region. Use **Test Proxy** to ping it and update the status.
 4. Use **Delete Selected** to remove entries. Proxy details are stored in the same `core/reviewbot.db` database.
+5. Proxies may be assigned at global, account, site, or project levels with weights and priorities via the database utilities.
 
 ### 5. Sites
 This tab lists all site templates found in the `templates/` directory. Selecting a site shows the fields defined for that website. Use it as a quick reference to verify that your template contains the necessary mappings.
+Remote repositories can be queried for available templates using the helper `list_remote_templates` in `core.site_registry` for easy importing.
 
 ### 6. Schedule
 The scheduler plans when each review will be posted.

--- a/core/proxy_manager.py
+++ b/core/proxy_manager.py
@@ -12,8 +12,8 @@ def load_proxies(file_path: str | None = None) -> list[str]:
     return [f"{r['ip_address']}:{r['port']}" for r in rows]
 
 
-def get_random_proxy() -> str | None:
-    proxy = database.fetch_proxy()
+def get_random_proxy(level: str = "global", target: str | int | None = None) -> str | None:
+    proxy = database.fetch_proxy_for_scope(level, target)
     if proxy:
         return f"{proxy['ip_address']}:{proxy['port']}"
     return None

--- a/core/site_registry.py
+++ b/core/site_registry.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List
 
+import requests
+
 SITE_DIR = Path("templates/sites")
 REGISTRY_PATH = Path("config/site_registry.json")
 
@@ -141,3 +143,19 @@ def export_site(name: str, destination: Path) -> None:
     data = get_site(name)
     with open(destination, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
+
+
+def list_remote_templates(repo_url: str) -> List[str]:
+    """List available site templates in a remote GitHub repository."""
+    api_url = (
+        repo_url.rstrip("/")
+        .replace("github.com", "api.github.com/repos")
+        + "/contents/templates/sites"
+    )
+    try:
+        resp = requests.get(api_url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception:
+        return []
+    return [item["name"] for item in data if item.get("name", "").endswith(".json")]

--- a/proxy/manager.py
+++ b/proxy/manager.py
@@ -6,13 +6,34 @@ from core import database
 
 
 class ProxyManager:
-    """Retrieve proxies from the SQLite database."""
+    """Retrieve and assign proxies from the SQLite database."""
 
     def __init__(self) -> None:
         pass
 
-    def get_proxy(self) -> Optional[str]:
-        proxy = database.fetch_proxy()
+    def get_proxy(
+        self, level: str = "global", target: str | int | None = None
+    ) -> Optional[str]:
+        proxy = database.fetch_proxy_for_scope(level, target)
+        if not proxy:
+            proxy = database.fetch_proxy()
         if proxy:
             return f"{proxy['ip_address']}:{proxy['port']}"
         return None
+
+    def assign_proxy(
+        self,
+        proxy_id: int,
+        level: str,
+        target: str | int | None = None,
+        weight: int = 1,
+        priority: int = 0,
+    ) -> None:
+        """Assign a proxy to a scope."""
+        database.assign_proxy(proxy_id, level, target, weight, priority)
+
+    def remove_assignment(
+        self, proxy_id: int, level: str, target: str | int | None = None
+    ) -> None:
+        """Remove a proxy assignment from a scope."""
+        database.remove_proxy_assignment(proxy_id, level, target)


### PR DESCRIPTION
## Summary
- support weighted proxy assignments scoped to global, account, site, or project levels
- expose helper to list site templates from remote GitHub repositories
- document proxy assignment and remote template discovery

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0713a6d8c8327abf4d1e5b94d9a0f