### PR TITLE
Add project-filtered logs with configurable size caps

### DIFF
--- a/config/log_settings.json
+++ b/config/log_settings.json
@@ -1,0 +1,4 @@
+{
+  "max_size_per_project": 1048576,
+  "max_size_overall": 10485760
+}


### PR DESCRIPTION
## Summary
- Add project selector for viewing logs per project
- Configure LogManager with per-project and global size limits
- Provide defaults via `config/log_settings.json`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b07c69dcb883279b89851f781e1abe