### PR TITLE
Track templates, sites and schedules per project

### DIFF
--- a/core/project_hub.py
+++ b/core/project_hub.py
@@ -113,3 +113,112 @@ def enforce_constraints(project: str) -> bool:
             if current > limit:
                 return False
     return True
+
+
+# --- Template Management -------------------------------------------------
+
+def list_templates(project: str) -> List[str]:
+    """Return templates assigned to a project."""
+    proj = get_project(project)
+    if not proj:
+        return []
+    return proj.get("resources", {}).get("templates", [])
+
+
+def add_template(project: str, template: str) -> bool:
+    """Assign a template to a project."""
+    data = _load_projects()
+    for proj in data:
+        if proj.get("name") == project:
+            resources = proj.setdefault("resources", {})
+            templates = resources.setdefault("templates", [])
+            if template not in templates:
+                templates.append(template)
+                _save_projects(data)
+            return True
+    return False
+
+
+def remove_template(project: str, template: str) -> bool:
+    """Remove a template from a project."""
+    data = _load_projects()
+    for proj in data:
+        if proj.get("name") == project:
+            templates = proj.setdefault("resources", {}).setdefault("templates", [])
+            if template in templates:
+                templates.remove(template)
+                _save_projects(data)
+            return True
+    return False
+
+
+# --- Site Management ------------------------------------------------------
+
+def list_sites(project: str) -> List[str]:
+    """Return sites associated with a project."""
+    proj = get_project(project)
+    if not proj:
+        return []
+    return proj.get("resources", {}).get("sites", [])
+
+
+def add_site(project: str, site: str) -> bool:
+    """Assign a site to a project."""
+    data = _load_projects()
+    for proj in data:
+        if proj.get("name") == project:
+            resources = proj.setdefault("resources", {})
+            sites = resources.setdefault("sites", [])
+            if site not in sites:
+                sites.append(site)
+                _save_projects(data)
+            return True
+    return False
+
+
+def remove_site(project: str, site: str) -> bool:
+    """Remove a site association from a project."""
+    data = _load_projects()
+    for proj in data:
+        if proj.get("name") == project:
+            sites = proj.setdefault("resources", {}).setdefault("sites", [])
+            if site in sites:
+                sites.remove(site)
+                _save_projects(data)
+            return True
+    return False
+
+
+# --- Schedule Configuration ----------------------------------------------
+
+def get_schedule(project: str) -> Any:
+    """Get schedule configuration for a project."""
+    proj = get_project(project)
+    if not proj:
+        return None
+    return proj.get("resources", {}).get("schedule")
+
+
+def set_schedule(project: str, schedule: Any) -> bool:
+    """Set schedule configuration for a project."""
+    data = _load_projects()
+    for proj in data:
+        if proj.get("name") == project:
+            resources = proj.setdefault("resources", {})
+            resources["schedule"] = schedule
+            _save_projects(data)
+            return True
+    return False
+
+
+def clear_schedule(project: str) -> bool:
+    """Remove schedule configuration from a project."""
+    data = _load_projects()
+    for proj in data:
+        if proj.get("name") == project:
+            resources = proj.setdefault("resources", {})
+            if "schedule" in resources:
+                resources.pop("schedule")
+                _save_projects(data)
+            return True
+    return False

--- a/tests/test_project_hub.py
+++ b/tests/test_project_hub.py
@@ -1,0 +1,38 @@
+import importlib
+import os
+import sys
+
+sys.path.append(os.path.abspath("."))
+
+from core import project_hub
+
+
+def setup(tmp_path):
+    project_hub.PROJECTS_FILE = tmp_path / "projects.json"
+    project_hub.GLOBAL_SETTINGS_FILE = tmp_path / "settings.json"
+    # reload to clear cached data if any
+    importlib.reload(project_hub)
+    project_hub.PROJECTS_FILE = tmp_path / "projects.json"
+    project_hub.GLOBAL_SETTINGS_FILE = tmp_path / "settings.json"
+    return project_hub
+
+
+def test_template_site_schedule(tmp_path):
+    ph = setup(tmp_path)
+    ph.add_project("alpha")
+    assert ph.list_projects() == ["alpha"]
+
+    ph.add_template("alpha", "tmpl1")
+    assert ph.list_templates("alpha") == ["tmpl1"]
+    ph.add_site("alpha", "site1")
+    assert ph.list_sites("alpha") == ["site1"]
+    ph.set_schedule("alpha", "schedule.json")
+    assert ph.get_schedule("alpha") == "schedule.json"
+
+    ph.remove_template("alpha", "tmpl1")
+    ph.remove_site("alpha", "site1")
+    ph.clear_schedule("alpha")
+    assert ph.list_templates("alpha") == []
+    assert ph.list_sites("alpha") == []
+    assert ph.get_schedule("alpha") is None
+


### PR DESCRIPTION
## Summary
- Allow project hub to manage templates, sites and schedule data per project
- Expand Projects tab to assign and view templates, sites and schedule configs
- Add regression test for project resource tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07bddff888327b9bdb8b6f3fd6827