### PR TITLE
Handle missing review queue directory

### DIFF
--- a/core/async_queue.py
+++ b/core/async_queue.py
@@ -34,12 +34,14 @@ class AsyncReviewQueue:
                     timestamp, review, template, proxy, account = item
                 self.queue.put((timestamp, review, template, proxy, account))
         except FileNotFoundError:
+            QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
             QUEUE_PATH.write_text("[]", encoding="utf-8")
         except json.JSONDecodeError:
             pass
 
     def _save(self) -> None:
         items = list(self.queue.queue)
+        QUEUE_PATH.parent.mkdir(parents=True, exist_ok=True)
         QUEUE_PATH.write_text(json.dumps(items, indent=2), encoding="utf-8")
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- create the review queue directory if missing before reading or writing

## Testing
- `pytest`
- `python - <<'PY'
from core.async_queue import AsyncReviewQueue
AsyncReviewQueue()
print('loaded queue')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b13a07c4588327bac30f3d829d04c4