### PR TITLE
Fix dashboard launch import path for direct script execution

### DIFF
--- a/dashboard/main_gui.py
+++ b/dashboard/main_gui.py
@@ -12,6 +12,11 @@ from tkinter.scrolledtext import ScrolledText
 
 import requests
 import socket
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from core import database
 from core.config_loader import load_json_config


### PR DESCRIPTION
### Motivation
- Running `python dashboard/main_gui.py` raised `ModuleNotFoundError: No module named 'core'` because the `dashboard/` directory was on `sys.path` instead of the repository root.

### Description
- Prepend the repository root to `sys.path` in `dashboard/main_gui.py` by adding a `PROJECT_ROOT` calculation and `sys.path.insert(0, ...)` before importing project modules so `core` and other packages can be resolved when the script is run directly.

### Testing
- Successfully compiled the modified file with `python -m py_compile dashboard/main_gui.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a56908ef308327b87acc78572ef5c6)